### PR TITLE
feat: add Sora explore scraping

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
 # Asynchronous Web Scraping Script for Image and Prompt Data
 
-This repository contains an enhanced JavaScript script designed for asynchronous scraping of image and prompt data from a web page. The script is executed in the browser's console and captures attributes such as the image URL and the associated prompt text.
+This repository contains an enhanced JavaScript script designed for asynchronous scraping of image and prompt data from Midjourney's Community Showcase as well as prompts and thumbnails from OpenAI's [Sora](https://sora.chatgpt.com/explore) explore page. The script is executed in the browser's console and captures attributes such as the image or video thumbnail URL and the associated prompt text.
 
 ## How to Use
 
-1. Navigate to the webpage where the images are displayed. Open the image that you wish to begin scraping data from.
+1. Navigate to the page you would like to scrape.
+   - **Midjourney**: open the first showcase item you want and ensure the modal is visible.
+   - **Sora**: open the [explore page](https://sora.chatgpt.com/explore) and load the items you want to collect.
 2. Access the web browser's developer console.
 3. Copy-paste the script from `script.js` into the console and execute it.
 
-The script will automatically scrape the data for 30 images, starting from the one you initially opened.
+For Midjourney, the script will automatically scrape the data for 30 images, starting from the one you initially opened. On Sora, it will gather the prompts and thumbnails for all explore cards currently loaded on the page.
 
 ## Output
 
@@ -25,6 +27,10 @@ The collected data is displayed in a fixed textarea at the top-left corner of th
 - Auto-navigation through images
 - Improved formatting in the output, including trailing commas
 - Quick actions for copying and clearing data
+
+## Testing
+
+Run `npm test` to perform a syntax check of `script.js`.
 
 ## Note
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "mj_showcase_scraper",
+  "version": "1.0.0",
+  "description": "Scraper for Midjourney Community Showcase and Sora explore prompts",
+  "scripts": {
+    "test": "node --check script.js"
+  },
+  "keywords": [
+    "scraper",
+    "midjourney",
+    "sora"
+  ],
+  "author": "",
+  "license": "MIT"
+}

--- a/script.js
+++ b/script.js
@@ -1,4 +1,5 @@
-async function extractData() {
+// Extract a single item's data from the Midjourney showcase modal
+async function extractMidjourneyData() {
   const imgElement = document.querySelector('img.modalImage');
   const promptElement = document.querySelector('#modalPrompt');
   const paramsElement = document.querySelector('code');
@@ -18,6 +19,35 @@ async function extractData() {
     url,
     prompt
   };
+}
+
+// Extract all prompts and thumbnails from the Sora explore page
+async function extractSoraData() {
+  const items = Array.from(document.querySelectorAll('a[href^="/explore/"], a[href^="/share/"]'));
+  const results = [];
+
+  items.forEach(item => {
+    let url = 'N/A';
+    let prompt = 'N/A';
+
+    const imgEl = item.querySelector('img') || item.querySelector('video');
+    if (imgEl) {
+      if (imgEl.tagName.toLowerCase() === 'img') {
+        url = imgEl.src;
+      } else if (imgEl.tagName.toLowerCase() === 'video') {
+        url = imgEl.poster || imgEl.src || 'N/A';
+      }
+    }
+
+    const promptEl = item.querySelector('p') || item.parentElement.querySelector('p');
+    if (promptEl) {
+      prompt = promptEl.innerText.replace(/\n+/g, ' ').trim();
+    }
+
+    results.push({ url, prompt });
+  });
+
+  return results;
 }
 
 function clickNextButton() {
@@ -70,13 +100,18 @@ function displayData(data) {
 }
 
 (async function main() {
-  const allData = [];
-  
-  for (let i = 0; i < 30; i++) {
-    const data = await extractData();
-    allData.push(data);
-    await clickNextButton();
+  if (location.hostname.includes('midjourney.com')) {
+    const allData = [];
+    for (let i = 0; i < 30; i++) {
+      const data = await extractMidjourneyData();
+      allData.push(data);
+      await clickNextButton();
+    }
+    displayData(allData);
+  } else if (location.hostname.includes('sora.chatgpt.com')) {
+    const data = await extractSoraData();
+    displayData(data);
+  } else {
+    console.error('Unsupported site');
   }
-  
-  displayData(allData);
 })();


### PR DESCRIPTION
## Summary
- scrape prompts and thumbnails from Sora explore page
- auto detect whether running on Midjourney or Sora and call the appropriate scraper
- document Sora support in README
- add package.json with test script and instructions

## Testing
- `node --version`
- `node --check script.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba488ceb20832193aae50b9cf3b23b